### PR TITLE
include schema prefix for zsp itemconfig2

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="1f171731-caad-4279-8103-23b8989ae3a6" name="Changes" comment="scope helper zsp itemIdColName reorder_id to id">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/pabuff/evs2helper/scope/ScopeHelper.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/pabuff/evs2helper/scope/ScopeHelper.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pom.xml" beforeDir="false" afterPath="$PROJECT_DIR$/pom.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="1f171731-caad-4279-8103-23b8989ae3a6" name="Changes" comment="scope helper zsp itemIdColName reorder_id to id">
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/pabuff/evs2helper/email/EmailService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/pabuff/evs2helper/email/EmailService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/pabuff/evs2helper/scope/ScopeHelper.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/pabuff/evs2helper/scope/ScopeHelper.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.36.20</version>
+	<version>3.36.21</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/scope/ScopeHelper.java
+++ b/src/main/java/org/pabuff/evs2helper/scope/ScopeHelper.java
@@ -244,14 +244,16 @@ public class ScopeHelper {
                 itemIdColName = "item_name";
             }
         }else if (projectScope.toLowerCase().contains("ems_zsp")) {
+            String schemaPrefix = "zsp.";
             itemType = ItemTypeEnum.METER_ZSP;
-            itemTableName = "meter_zsp";//"recorder";
-            itemReadingTableName = "meter_reading_zsp";//"energy_etc";
+            itemTableName = schemaPrefix +"meter_zsp";
+            itemReadingTableName = schemaPrefix+ "meter_reading_zsp";//"energy_etc";
+            tenantTableName = schemaPrefix + "tenant_zsp";//"tenant";
+            itemGroupTableName = schemaPrefix + "recgroup";
+            tenantTargetGroupTableName = schemaPrefix + "tenantgroup";
+
             itemReadingIndexColName = "id";//"egyid";
             itemReadingIdColName = "recorder_id";//"egyinstkey";
-            itemGroupTableName = "recgroup";
-            tenantTableName = "tenant_zsp";//"tenant";
-            tenantTargetGroupTableName = "tenantgroup";
             itemIdColName = "id";//"recid";
 //            itemNameColName = "recdisplayname";
             itemNameColName = "rec_displayname";//"recid";


### PR DESCRIPTION
This pull request includes changes to the `.idea/workspace.xml` file and enhancements to the `ScopeHelper` class in the `src/main/java/org/pabuff/evs2helper/scope/ScopeHelper.java` file. The most important changes include updating the `ChangeListManager` and refactoring the `getItemTypeConfig2` method to use a schema prefix.

Changes to `.idea/workspace.xml`:

* Updated the `ChangeListManager` to include changes to `ScopeHelper.java` and `workspace.xml`. (`.idea/workspace.xml`)

Enhancements to `ScopeHelper`:

* Refactored the `getItemTypeConfig2` method to use a `schemaPrefix` for table names, improving code readability and maintainability. (`src/main/java/org/pabuff/evs2helper/scope/ScopeHelper.java`)