### PR TITLE
TcmHelper2 sutd update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.56.1</version>
+	<version>3.56.3</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/TcmHelper2.java
+++ b/src/main/java/org/pabuff/evs2helper/TcmHelper2.java
@@ -28,6 +28,8 @@ public class TcmHelper2 {
     private String tcmPathNusVh;
     @Value("${tcm.path.ntu_mr}")
     private String tcmPathNtuMr;
+    @Value("${tcm.path.sutd_campus}")
+    private String tcmPathSutdCampus;
 
     @Value("${tcm.ept.do_one_topup}")
     private String tcmEptDoOneTopup;
@@ -127,6 +129,8 @@ public class TcmHelper2 {
                 return tcmPathNusVh;
             } else if ("ntu_mr".equals(siteTag)) {
                 return tcmPathNtuMr;
+            } else if("sutd_campus".equals(siteTag)) {
+                return tcmPathSutdCampus;
             }
         }
         return tcmPath;


### PR DESCRIPTION
This pull request updates the EVS2 Helper module to add support for the `sutd_campus` TCM path. The main changes are to introduce a new configuration property and ensure it is used in the helper logic.

**Configuration and logic updates:**

* Added a new property `tcmPathSutdCampus` to `TcmHelper2` and mapped it to the `tcm.path.sutd_campus` configuration.
* Updated the `getTcmPath` method in `TcmHelper2` to return the new `tcmPathSutdCampus` value when the `siteTag` is `sutd_campus`.

**Version update:**

* Bumped the module version in `pom.xml` from `3.56.1` to `3.56.3`.