### PR TITLE
add normalizedMeterAddress function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.58.0</version>
+	<version>3.58.1</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
+++ b/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
@@ -121,7 +121,7 @@ public class MeterHelper {
             } else {
                 int startIndex = building.indexOf("RC");
                 if (startIndex != -1) {
-                    value = Character.getNumericValue(building.charAt(startIndex + 2));
+                    value = Character.getNumericValue(building.charAt(startIndex + 3));
                 }
             }
             if(value == null) {

--- a/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
+++ b/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
@@ -147,7 +147,7 @@ public class MeterHelper {
                     }
                 }
             } else if ("pag".equalsIgnoreCase(source)) {
-                String rowBuilding = (String) row.get("pa_building_value");
+                String rowBuilding = (String) row.get("pag_building_value");
                 if (normalizedBuilding.contains(rowBuilding)) {
                     normalizedAddrInfo.put("building", row.get("result_value"));
                     return Map.of("data", normalizedAddrInfo);
@@ -194,199 +194,199 @@ public class MeterHelper {
                         "result_value", "36 College Ave East",
                         "mms_building_value", "36 College Ave East",
                         "mms_block", "36",
-                        "pa_building_value", "36 College Ave East"
+                        "pag_building_value", "36 College Ave East"
                 ),
                 Map.of(
                         "result_value", "26 College Ave East",
                         "mms_building_value", "26 College Ave East",
                         "mms_block", "26",
-                        "pa_building_value", "26 College Ave East"
+                        "pag_building_value", "26 College Ave East"
                 ),
                 Map.of(
                         "result_value", "22 College Ave East",
                         "mms_building_value", "22 College Ave East",
                         "mms_block", "22",
-                        "pa_building_value", "22 College Ave East"
+                        "pag_building_value", "22 College Ave East"
                 ),
                 Map.of(
                         "result_value", "8 College Ave East",
                         "mms_building_value", "8 College Ave East",
                         "mms_block", "8",
-                        "pa_building_value", "8 College Ave East"
+                        "pag_building_value", "8 College Ave East"
                 ),
                 Map.of(
                         "result_value", "5 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "5",
-                        "pa_building_value", "5 Prince George's Residence"
+                        "pag_building_value", "5 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "6 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "6",
-                        "pa_building_value", "6 Prince George's Residence"
+                        "pag_building_value", "6 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "7 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "7",
-                        "pa_building_value", "7 Prince George's Residence"
+                        "pag_building_value", "7 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "8 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "8",
-                        "pa_building_value", "8 Prince George's Residence"
+                        "pag_building_value", "8 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "11 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "11",
-                        "pa_building_value", "11 Prince George's Residence"
+                        "pag_building_value", "11 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "12 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "12",
-                        "pa_building_value", "12 Prince George's Residence"
+                        "pag_building_value", "12 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "13 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "13",
-                        "pa_building_value", "13 Prince George's Residence"
+                        "pag_building_value", "13 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "14 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "14",
-                        "pa_building_value", "14 Prince George's Residence"
+                        "pag_building_value", "14 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "17 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "17",
-                        "pa_building_value", "17 Prince George's Residence"
+                        "pag_building_value", "17 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "18 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "18",
-                        "pa_building_value", "18 Prince George's Residence"
+                        "pag_building_value", "18 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "19 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "19",
-                        "pa_building_value", "19 Prince George's Residence"
+                        "pag_building_value", "19 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "21 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "21",
-                        "pa_building_value", "21 Prince George's Residence"
+                        "pag_building_value", "21 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "23 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "23",
-                        "pa_building_value", "23 Prince George's Residence"
+                        "pag_building_value", "23 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "25 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "25",
-                        "pa_building_value", "25 Prince George's Residence"
+                        "pag_building_value", "25 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "26 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "26",
-                        "pa_building_value", "26 Prince George's Residence"
+                        "pag_building_value", "26 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "28 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "28",
-                        "pa_building_value", "28 Prince George's Residence"
+                        "pag_building_value", "28 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "30 Prince George's Residence",
                         "mms_building_value", "Prince George's Residence",
                         "mms_block", "30",
-                        "pa_building_value", "30 Prince George's Residence"
+                        "pag_building_value", "30 Prince George's Residence"
                 ),
                 Map.of(
                         "result_value", "Maple Residence",
                         "mms_building_value", "Maple Residences",
                         "mms_block", "Maple Residences",
-                        "pa_building_value", "Maple Residence"
+                        "pag_building_value", "Maple Residence"
                 ),
                 Map.of(
                         "result_value", "Valour House Building A",
                         "mms_building_value", "Valour House Building A",
                         "mms_block", "A",
-                        "pa_building_value", "Valour House Building A"
+                        "pag_building_value", "Valour House Building A"
                 ),
                 Map.of(
                         "result_value", "25E Lower Kent Ridge Rd",
                         "mms_building_value", "25E Lower Kent Ridge Rd",
                         "mms_block", "",
-                        "pa_building_value", "25E Lower Kent Ridge Rd"
+                        "pag_building_value", "25E Lower Kent Ridge Rd"
                 ),
                 Map.of(
                         "result_value", "Block A 10 Heng Mui Keng Ter",
                         "mms_building_value", "Block A 10 Heng Mui Keng Ter",
                         "mms_block", "A",
-                        "pa_building_value", "Block A 10 Heng Mui Keng Ter"
+                        "pag_building_value", "Block A 10 Heng Mui Keng Ter"
                 ),
                 Map.of(
                         "result_value", "Block B 10 Heng Mui Keng Ter",
                         "mms_building_value", "Block B 10 Heng Mui Keng Ter",
                         "mms_block", "B",
-                        "pa_building_value", "Block B 10 Heng Mui Keng Ter"
+                        "pag_building_value", "Block B 10 Heng Mui Keng Ter"
                 ),
                 Map.of(
                         "result_value", "Block A 20 Heng Mui Keng Ter",
                         "mms_building_value", "Block A 20 Heng Mui Keng Ter",
                         "mms_block", "A",
-                        "pa_building_value", "Block A 20 Heng Mui Keng Ter"
+                        "pag_building_value", "Block A 20 Heng Mui Keng Ter"
                 ),
                 Map.of(
                         "result_value", "Block B 20 Heng Mui Keng Ter",
                         "mms_building_value", "Block B 20 Heng Mui Keng Ter",
                         "mms_block", "B",
-                        "pa_building_value", "Block B 20 Heng Mui Keng Ter"
+                        "pag_building_value", "Block B 20 Heng Mui Keng Ter"
                 ),
                 Map.of(
                         "result_value", "Block B 1A Kent Ridge Rd",
                         "mms_building_value", "Block B 1A Kent Ridge Rd",
                         "mms_block", "B",
-                        "pa_building_value", "Block B 1A Kent Ridge Rd"
+                        "pag_building_value", "Block B 1A Kent Ridge Rd"
                 ),
                 Map.of(
                         "result_value", "Block C 1A Kent Ridge Rd",
                         "mms_building_value", "Block C 1A Kent Ridge Rd",
                         "mms_block", "C",
-                        "pa_building_value", "Block C 1A Kent Ridge Rd"
+                        "pag_building_value", "Block C 1A Kent Ridge Rd"
                 ),
                 Map.of(
                         "result_value", "Block D 1A Kent Ridge Rd",
                         "mms_building_value", "Block D 1A Kent Ridge Rd",
                         "mms_block", "D",
-                        "pa_building_value", "Block D 1A Kent Ridge Rd"
+                        "pag_building_value", "Block D 1A Kent Ridge Rd"
                 ),
                 Map.of(
                         "result_value", "Block A 10 Kent Ridge Dr",
                         "mms_building_value", "Block A 10 Kent Ridge Dr",
                         "mms_block", "A",
-                        "pa_building_value", "Block A 10 Kent Ridge Dr"
+                        "pag_building_value", "Block A 10 Kent Ridge Dr"
                 ),
                 Map.of(
                         "result_value", "Block A 12 Kent Ridge Dr",
                         "mms_building_value", "Block A 12 Kent Ridge Dr",
                         "mms_block", "A",
-                        "pa_building_value", "Block A 12 Kent Ridge Dr"
+                        "pag_building_value", "Block A 12 Kent Ridge Dr"
                 )
         );
 }

--- a/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
+++ b/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
@@ -91,19 +91,302 @@ public class MeterHelper {
         return meterInfo.getFirst();
     }
 
-    public Map<String,Object> getMeterBuilding(String building){
-        if(building==null || building.isEmpty()){
+    public Map<String, Object> getNormalizedMeterAddress(Map<String,Object> request) {
+        String source = (String) request.get("source");
+        String building = (String) request.get("building");
+        String block = (String) request.get("block");
+        String unit = (String) request.get("unit");
+        if (building == null || building.isEmpty()) {
             return Collections.singletonMap("error", "building is null or empty");
         }
-        String lowerCaseBuilding = building.toLowerCase();
-        if(lowerCaseBuilding.contains("prince george")){
-            building = "Prince George's Residence";
-        }else if(lowerCaseBuilding.contains("college ave west")){
-            // remove the rest of the string after "College Ave West"
-            building = building.replaceFirst("(?i)(.*College Ave West).*", "$1");
-        }else if(lowerCaseBuilding.contains("maple residence")){
-            building = "Maple Residence";
+        if( source == null || source.isEmpty()) {
+            return Collections.singletonMap("error", "source is null or empty");
         }
-        return Collections.singletonMap("result", building);
+        if(!source.equalsIgnoreCase("pag") && !source.equalsIgnoreCase("mms")) {
+            return Collections.singletonMap("error", "source is not valid");
+        }
+        String normalizedBuilding = building.trim();
+
+        String rc1aBlock = "RC1A";
+        String rc1bBlock = "RC1B";
+        String rc2Block = "RC2";
+        String rc3aBlock = "RC3A";
+        String rc3bBlock = "RC3B";
+        if (normalizedBuilding.contains("College Ave West")) {
+            int index = normalizedBuilding.indexOf("College Ave West");
+            normalizedBuilding = normalizedBuilding.substring(0, index + "College Ave West".length());
+            Integer value = null;
+            if ("mms".equalsIgnoreCase(source)) {
+                value = Integer.parseInt(String.valueOf(unit.charAt(2)));
+            } else {
+                int startIndex = building.indexOf("RC");
+                if (startIndex != -1) {
+                    value = Character.getNumericValue(building.charAt(startIndex + 2));
+                }
+            }
+            if(value == null) {
+                return Collections.singletonMap("error", "unit is not valid");
+            }
+            return switch (block) {
+                case "10" -> resolveRcBlock(source,value, normalizedBuilding, rc1aBlock, rc1bBlock);
+                case "12" -> Map.of("data", Map.of("building", normalizedBuilding, "block", rc2Block));
+                case "28" -> resolveRcBlock(source,value, normalizedBuilding, rc3aBlock, rc3bBlock);
+                default -> Collections.singletonMap("error", "block is not valid");
+            };
+        }
+        // Normal lookup
+        Map<String, Object> normalizedAddrInfo = new HashMap<>();
+        for (Map<String, Object> row : meterAddrLookupTable) {
+            if ("mms".equalsIgnoreCase(source)) {
+                String rowBuilding = (String) row.get("mms_building_value");
+                String rowBlock = (String) row.get("mms_block");
+                if (normalizedBuilding.contains(rowBuilding)) {
+                    if (block == null || block.equals(rowBlock)) {
+                        normalizedAddrInfo.put("building", row.get("result_value"));
+                        return Map.of("data", normalizedAddrInfo);
+                    }
+                }
+            } else if ("pag".equalsIgnoreCase(source)) {
+                String rowBuilding = (String) row.get("pa_building_value");
+                if (normalizedBuilding.contains(rowBuilding)) {
+                    normalizedAddrInfo.put("building", row.get("result_value"));
+                    return Map.of("data", normalizedAddrInfo);
+                }
+            }
+        }
+        return Collections.singletonMap("error", "no match found");
     }
+
+    private Map<String, Object> resolveRcBlock(String source, int value, String building, String blockA, String blockB) {
+        int rcaMinValue = 1;
+        int rcaMaxValue = 2;
+        int rcbMinValue = 3;
+        int rcbMaxValue = 8;
+        if("mms".equalsIgnoreCase(source)) {
+            if (value >= rcaMinValue && value <= rcaMaxValue) {
+                    return Map.of("data", Map.of(
+                                    "building", building,
+                                    "block", blockA));
+            }
+            if (value >= rcbMinValue && value <= rcbMaxValue) {
+                return Map.of("data", Map.of(
+                                "building", building,
+                                "block", blockB));
+            }
+        } else if("pag".equalsIgnoreCase(source)) {
+            if("A".equalsIgnoreCase(blockA)){
+                return Map.of("data", Map.of(
+                                "building", building,
+                                "block", blockA));
+            }else if("B".equalsIgnoreCase(blockB)){
+                return Map.of("data", Map.of(
+                                "building", building,
+                                "block", blockB));
+            }else{
+                return Collections.singletonMap("error", "block is not valid");
+            }
+        }
+        return Collections.singletonMap("error", "block is not valid");
+    }
+
+    private static final List<Map<String, Object>> meterAddrLookupTable = List.of(
+                Map.of(
+                        "result_value", "36 College Ave East",
+                        "mms_building_value", "36 College Ave East",
+                        "mms_block", "36",
+                        "pa_building_value", "36 College Ave East"
+                ),
+                Map.of(
+                        "result_value", "26 College Ave East",
+                        "mms_building_value", "26 College Ave East",
+                        "mms_block", "26",
+                        "pa_building_value", "26 College Ave East"
+                ),
+                Map.of(
+                        "result_value", "22 College Ave East",
+                        "mms_building_value", "22 College Ave East",
+                        "mms_block", "22",
+                        "pa_building_value", "22 College Ave East"
+                ),
+                Map.of(
+                        "result_value", "8 College Ave East",
+                        "mms_building_value", "8 College Ave East",
+                        "mms_block", "8",
+                        "pa_building_value", "8 College Ave East"
+                ),
+                Map.of(
+                        "result_value", "5 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "5",
+                        "pa_building_value", "5 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "6 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "6",
+                        "pa_building_value", "6 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "7 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "7",
+                        "pa_building_value", "7 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "8 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "8",
+                        "pa_building_value", "8 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "11 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "11",
+                        "pa_building_value", "11 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "12 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "12",
+                        "pa_building_value", "12 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "13 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "13",
+                        "pa_building_value", "13 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "14 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "14",
+                        "pa_building_value", "14 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "17 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "17",
+                        "pa_building_value", "17 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "18 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "18",
+                        "pa_building_value", "18 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "19 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "19",
+                        "pa_building_value", "19 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "21 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "21",
+                        "pa_building_value", "21 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "23 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "23",
+                        "pa_building_value", "23 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "25 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "25",
+                        "pa_building_value", "25 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "26 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "26",
+                        "pa_building_value", "26 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "28 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "28",
+                        "pa_building_value", "28 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "30 Prince George's Residence",
+                        "mms_building_value", "Prince George's Residence",
+                        "mms_block", "30",
+                        "pa_building_value", "30 Prince George's Residence"
+                ),
+                Map.of(
+                        "result_value", "Maple Residence",
+                        "mms_building_value", "Maple Residences",
+                        "mms_block", "Maple Residences",
+                        "pa_building_value", "Maple Residence"
+                ),
+                Map.of(
+                        "result_value", "Valour House Building A",
+                        "mms_building_value", "Valour House Building A",
+                        "mms_block", "A",
+                        "pa_building_value", "Valour House Building A"
+                ),
+                Map.of(
+                        "result_value", "25E Lower Kent Ridge Rd",
+                        "mms_building_value", "25E Lower Kent Ridge Rd",
+                        "mms_block", "",
+                        "pa_building_value", "25E Lower Kent Ridge Rd"
+                ),
+                Map.of(
+                        "result_value", "Block A 10 Heng Mui Keng Ter",
+                        "mms_building_value", "Block A 10 Heng Mui Keng Ter",
+                        "mms_block", "A",
+                        "pa_building_value", "Block A 10 Heng Mui Keng Ter"
+                ),
+                Map.of(
+                        "result_value", "Block B 10 Heng Mui Keng Ter",
+                        "mms_building_value", "Block B 10 Heng Mui Keng Ter",
+                        "mms_block", "B",
+                        "pa_building_value", "Block B 10 Heng Mui Keng Ter"
+                ),
+                Map.of(
+                        "result_value", "Block A 20 Heng Mui Keng Ter",
+                        "mms_building_value", "Block A 20 Heng Mui Keng Ter",
+                        "mms_block", "A",
+                        "pa_building_value", "Block A 20 Heng Mui Keng Ter"
+                ),
+                Map.of(
+                        "result_value", "Block B 20 Heng Mui Keng Ter",
+                        "mms_building_value", "Block B 20 Heng Mui Keng Ter",
+                        "mms_block", "B",
+                        "pa_building_value", "Block B 20 Heng Mui Keng Ter"
+                ),
+                Map.of(
+                        "result_value", "Block B 1A Kent Ridge Rd",
+                        "mms_building_value", "Block B 1A Kent Ridge Rd",
+                        "mms_block", "B",
+                        "pa_building_value", "Block B 1A Kent Ridge Rd"
+                ),
+                Map.of(
+                        "result_value", "Block C 1A Kent Ridge Rd",
+                        "mms_building_value", "Block C 1A Kent Ridge Rd",
+                        "mms_block", "C",
+                        "pa_building_value", "Block C 1A Kent Ridge Rd"
+                ),
+                Map.of(
+                        "result_value", "Block D 1A Kent Ridge Rd",
+                        "mms_building_value", "Block D 1A Kent Ridge Rd",
+                        "mms_block", "D",
+                        "pa_building_value", "Block D 1A Kent Ridge Rd"
+                ),
+                Map.of(
+                        "result_value", "Block A 10 Kent Ridge Dr",
+                        "mms_building_value", "Block A 10 Kent Ridge Dr",
+                        "mms_block", "A",
+                        "pa_building_value", "Block A 10 Kent Ridge Dr"
+                ),
+                Map.of(
+                        "result_value", "Block A 12 Kent Ridge Dr",
+                        "mms_building_value", "Block A 12 Kent Ridge Dr",
+                        "mms_block", "A",
+                        "pa_building_value", "Block A 12 Kent Ridge Dr"
+                )
+        );
 }


### PR DESCRIPTION
This pull request introduces a new method for normalizing meter addresses and significantly expands the logic and lookup data for building and block resolution. The main focus is to provide a more robust and extensible way to map incoming meter address requests to standardized building and block values, supporting both "pag" and "mms" sources.

**Enhancements to meter address normalization:**

* Added a new method `getNormalizedMeterAddress` to `MeterHelper.java`, which takes a request map and normalizes building/block/unit information based on the source ("pag" or "mms"). The method performs input validation, handles special cases for "College Ave West", and uses a comprehensive lookup table for other addresses.
* Implemented a helper method `resolveRcBlock` to encapsulate logic for resolving RC blocks based on source and unit/block values, improving code maintainability and readability.

**Data structure improvements:**

* Introduced a static `meterAddrLookupTable` containing mappings between various building/block names and their normalized forms, supporting both "pag" and "mms" sources. This allows for more flexible and maintainable address resolution.

**Deprecation of old logic:**

* Replaced the previous `getMeterBuilding` method with the new, more general approach, removing hardcoded string manipulations in favor of table-driven logic.

**Version update:**

* Updated the project version in `pom.xml` from `3.58.0` to `3.58.1` to reflect these changes.