### PR TITLE
update building for maple residences

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.58.3</version>
+	<version>3.58.4</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
+++ b/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
@@ -326,7 +326,7 @@ public class MeterHelper {
                 "pag_building_value", "30 Prince George's Residence"
         ),
         Map.of(
-                "result_building_value", "Maple Residence",
+                "result_building_value", "Maple Residences",
                 "result_block_value", "Maple Residences",
                 "mms_building_value", "Maple Residences",
                 "pag_building_value", "Maple Residence"


### PR DESCRIPTION
This pull request includes a minor version bump and a correction to a building name string in the `MeterHelper` class.

- Version update:
  * Bumped the project version in `pom.xml` from `3.58.3` to `3.58.4` to reflect the latest changes.

- Data correction:
  * Corrected the `result_building_value` from "Maple Residence" to "Maple Residences" in the `resolveRcBlock` method of `MeterHelper.java` for consistency with other building value entries.