### PR TITLE
fix bug 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.58.7</version>
+	<version>3.58.8</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
+++ b/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
@@ -143,7 +143,7 @@ public class MeterHelper {
             if ("mms".equalsIgnoreCase(source)) {
                 String rowBuilding = (String) row.get("mms_building_value");
                 String rowBlock = (String) row.get("result_block_value");
-                if (normalizedBuilding.equalsIgnoreCase(rowBuilding) || mmsPgprBuildingName.equalsIgnoreCase(normalizedBuilding) ) {
+                if (normalizedBuilding.equalsIgnoreCase(rowBuilding)) {
                     if (block == null || block.equalsIgnoreCase(rowBlock)) {
                         normalizedAddrInfo.put("building", row.get("result_building_value"));
                         normalizedAddrInfo.put("block", row.get("result_block_value"));


### PR DESCRIPTION
This pull request includes a version bump for the `evs2helper` module and a logic update in the `MeterHelper` class to improve address normalization accuracy.

Version update:

* Bumped the project version in `pom.xml` from `3.58.7` to `3.58.8`.

Logic correction:

* In `MeterHelper.java`, updated the logic in `getNormalizedMeterAddress` to only match on `normalizedBuilding` and `rowBuilding`, removing the additional check for `mmsPgprBuildingName`. This makes the address normalization more precise and avoids unintended matches.