### PR TITLE
add hall site for tcm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.58.8</version>
+	<version>3.58.9</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/TcmHelper2.java
+++ b/src/main/java/org/pabuff/evs2helper/TcmHelper2.java
@@ -30,6 +30,8 @@ public class TcmHelper2 {
     private String tcmPathNtuMr;
     @Value("${tcm.path.sutd_campus}")
     private String tcmPathSutdCampus;
+    @Value("{tcm.path.five_halls}")
+    private String tcmPathFiveHalls;
 
     @Value("${tcm.ept.do_one_topup}")
     private String tcmEptDoOneTopup;
@@ -115,6 +117,7 @@ public class TcmHelper2 {
         } catch (Exception e) {
             return tcmPath;
         }
+        List<String> hallsSiteTagList = List.of("nus_krh", "nus_sh", "nus_eh", "nus_th", "nus_ke7h");
         if (resp != null && !resp.isEmpty()) {
             String siteTag = (String) resp.getFirst().get("site_tag");
             if ("nus_pgpr".equals(siteTag)) {
@@ -131,6 +134,8 @@ public class TcmHelper2 {
                 return tcmPathNtuMr;
             } else if("sutd_campus".equals(siteTag)) {
                 return tcmPathSutdCampus;
+            } else if (hallsSiteTagList.contains(siteTag)) {
+                return tcmPathFiveHalls;
             }
         }
         return tcmPath;


### PR DESCRIPTION
This pull request updates the EVS2 Helper module to add support for a new group of "Five Halls" sites. The main changes involve introducing a new configuration property and updating the logic in `TcmHelper2` to return the correct path for these sites.

Configuration updates:

* Added a new configuration property `tcm.path.five_halls` (note: missing ` in annotation, likely a bug) and corresponding field `tcmPathFiveHalls` in `TcmHelper2` to support the Five Halls group.

Logic updates in `TcmHelper2`:

* Defined a list of site tags representing the Five Halls (`nus_krh`, `nus_sh`, `nus_eh`, `nus_th`, `nus_ke7h`) in `getTcmPath`.
* Updated the site tag handling logic in `getTcmPath` to return the new `tcmPathFiveHalls` when the site tag matches any in the Five Halls group.

Other:

* Bumped the module version from `3.58.8` to `3.58.9` in `pom.xml`.