### PR TITLE
add evs2 address lookup table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.58.11</version>
+	<version>3.58.12</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
+++ b/src/main/java/org/pabuff/evs2helper/device/MeterHelper.java
@@ -410,14 +410,14 @@ public class MeterHelper {
         Map.of(
                 "result_scope_value", "evs2_nus",
                 "result_site_value","nus_rvrc",
-                "result_building_value", "25E Lower Kent Ridge Rd",
+                "result_building_value", "Ridge View Residence",
                 "result_block_value", "E",
                 "mms_building_value", "25E Lower Kent Ridge Rd",
                 "pag_building_value", "25E Lower Kent Ridge Rd"
         ),
         Map.of(
                 "result_scope_value", "evs2_nus",
-                "result_site_value","nus_rvrc",
+                "result_site_value","nus_krh",
                 "result_building_value", "Block A 10 Heng Mui Keng Ter",
                 "result_block_value", "A",
                 "mms_building_value", "Block A 10 Heng Mui Keng Ter",
@@ -425,7 +425,7 @@ public class MeterHelper {
         ),
         Map.of(
                 "result_scope_value", "evs2_nus",
-                "result_site_value","nus_rvrc",
+                "result_site_value","nus_krh",
                 "result_building_value", "Block B 10 Heng Mui Keng Ter",
                 "result_block_value", "B",
                 "mms_building_value", "Block B 10 Heng Mui Keng Ter",
@@ -433,7 +433,7 @@ public class MeterHelper {
         ),
         Map.of(
                 "result_scope_value", "evs2_nus",
-                "result_site_value","nus_rvrc",
+                "result_site_value","nus_sh",
                 "result_building_value", "Block A 20 Heng Mui Keng Ter",
                 "result_block_value", "A",
                 "mms_building_value", "Block A 20 Heng Mui Keng Ter",
@@ -441,7 +441,7 @@ public class MeterHelper {
         ),
         Map.of(
                 "result_scope_value", "evs2_nus",
-                "result_site_value","nus_rvrc",
+                "result_site_value","nus_sh",
                 "result_building_value", "Block B 20 Heng Mui Keng Ter",
                 "result_block_value", "B",
                 "mms_building_value", "Block B 20 Heng Mui Keng Ter",
@@ -449,7 +449,7 @@ public class MeterHelper {
         ),
         Map.of(
                 "result_scope_value", "evs2_nus",
-                "result_site_value","nus_rvrc",
+                "result_site_value","nus_ke7h",
                 "result_building_value", "Block B 1A Kent Ridge Rd",
                 "result_block_value", "B",
                 "mms_building_value", "Block B 1A Kent Ridge Rd",
@@ -457,7 +457,7 @@ public class MeterHelper {
         ),
         Map.of(
                 "result_scope_value", "evs2_nus",
-                "result_site_value","nus_rvrc",
+                "result_site_value","nus_ke7h",
                 "result_building_value", "Block C 1A Kent Ridge Rd",
                 "result_block_value", "C",
                 "mms_building_value", "Block C 1A Kent Ridge Rd",
@@ -465,7 +465,7 @@ public class MeterHelper {
         ),
         Map.of(
                 "result_scope_value", "evs2_nus",
-                "result_site_value","nus_rvrc",
+                "result_site_value","nus_ke7h",
                 "result_building_value", "Block D 1A Kent Ridge Rd",
                 "result_block_value", "D",
                 "mms_building_value", "Block D 1A Kent Ridge Rd",
@@ -473,7 +473,7 @@ public class MeterHelper {
         ),
         Map.of(
                 "result_scope_value", "evs2_nus",
-                "result_site_value","nus_rvrc",
+                "result_site_value","nus_eh",
                 "result_building_value", "Block A 10 Kent Ridge Dr",
                 "result_block_value", "A",
                 "mms_building_value", "Block A 10 Kent Ridge Dr",
@@ -481,7 +481,7 @@ public class MeterHelper {
         ),
         Map.of(
                 "result_scope_value", "evs2_nus",
-                "result_site_value","nus_rvrc",
+                "result_site_value","nus_th",
                 "result_building_value", "Block A 12 Kent Ridge Dr",
                 "result_block_value", "A",
                 "mms_building_value", "Block A 12 Kent Ridge Dr",


### PR DESCRIPTION
This pull request updates the version of the `evs2helper` module and makes several corrections to building and site mappings for NUS locations in the `MeterHelper` class. The main focus is on improving the accuracy of the site and building information returned by the `resolveRcBlock` method.

**Updates to NUS building and site mappings:**

- Changed the `result_building_value` for RVRC block E from `"25E Lower Kent Ridge Rd"` to `"Ridge View Residence"` to better reflect the actual building name.
- Updated several `result_site_value` entries from `"nus_rvrc"` to more accurate site codes (e.g., `"nus_krh"`, `"nus_sh"`, `"nus_ke7h"`, `"nus_eh"`, `"nus_th"`) for various blocks, improving the precision of site identification.

**Version bump:**

- Updated the project version in `pom.xml` from `3.58.11` to `3.58.12`.