### PR TITLE
acControllerResolver 5halls update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.58.12</version>
+	<version>3.58.13</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/cpc/AcControllerResolver.java
+++ b/src/main/java/org/pabuff/evs2helper/cpc/AcControllerResolver.java
@@ -15,6 +15,8 @@ public class AcControllerResolver {
     public String pagMqttAgentVhPath;
     @Value("${pag.mqtt.agent.pgpr.path}")
     public String pagMqttAgentPgprPath;
+    @Value("${pag.mqtt.agent.five_halls.path}")
+    public String pagMqttAgentFiveHallsPath;
 
     static private final List<String> pgpr6AdhocMeter = List.of(
             "201808000338",
@@ -116,10 +118,29 @@ public class AcControllerResolver {
             topicPub = "evs2/nus/" + topicInfix + "/" + gw;
             topicSub = "evs2/nus/" + topicInfix + "/" + gw + "/" + meterSn;
             pmaPath = pagMqttAgentPgprPath;
+        } else if(isFiveHalls(siteTag)){
+            String gw = "gw1";
+            block = block.toLowerCase();
+            String site = siteTag.split("_")[1];
+
+            String topicInfix = site + block;
+            topicPub = "evs2/nus/" + topicInfix + "/" + gw;
+            topicSub = "evs2/nus/" + topicInfix + "/" + gw + "/" + meterSn;
+            pmaPath = pagMqttAgentFiveHallsPath;
         } else {
             return Map.of("error", "Unsupported site tag: " + siteTag);
         }
 
         return Map.of("topic_pub", topicPub, "topic_sub", topicSub, "pma_path", pmaPath);
+    }
+
+    Boolean isFiveHalls(String siteTag){
+        if(siteTag == null || siteTag.isEmpty()){
+            return false;
+        }
+
+        siteTag = siteTag.toLowerCase();
+        return "nus_eh".equals(siteTag) || "nus_ke7h".equals(siteTag) || "nus_krh".equals(siteTag)
+                || "nus_sh".equals(siteTag) || "nus_th".equals(siteTag);
     }
 }


### PR DESCRIPTION
This pull request adds support for a new "Five Halls" site type in the `AcControllerResolver` logic, allowing the resolver to handle additional site tags and configure the appropriate MQTT topics and agent path. It also bumps the project version.

**Support for Five Halls site type:**

* Added a new configuration property `pagMqttAgentFiveHallsPath` to `AcControllerResolver` for the Five Halls agent path.
* Updated `resolveAcControlInfo` to recognize Five Halls site tags, set the correct MQTT topics, and use the new agent path.
* Introduced the `isFiveHalls` helper method to identify Five Halls site tags.

**Version update:**

* Bumped the project version in `pom.xml` from `3.58.12` to `3.58.13`.