### PR TITLE
misc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.58.13</version>
+	<version>3.58.14</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/cpc/AcControllerResolver.java
+++ b/src/main/java/org/pabuff/evs2helper/cpc/AcControllerResolver.java
@@ -17,7 +17,9 @@ public class AcControllerResolver {
     public String pagMqttAgentPgprPath;
     @Value("${pag.mqtt.agent.five_halls.path}")
     public String pagMqttAgentFiveHallsPath;
+    private static final List<String> siteTagNus5HallsList = List.of("nus_eh", "nus_ke7h", "nus_krh", "nus_sh", "nus_th");
 
+    // 48 meters at PGPR 6 are controlled by the ac controller at pgpr 5
     static private final List<String> pgpr6AdhocMeter = List.of(
             "201808000338",
             "201808000340",
@@ -118,7 +120,7 @@ public class AcControllerResolver {
             topicPub = "evs2/nus/" + topicInfix + "/" + gw;
             topicSub = "evs2/nus/" + topicInfix + "/" + gw + "/" + meterSn;
             pmaPath = pagMqttAgentPgprPath;
-        } else if(isFiveHalls(siteTag)){
+        } else if(isNus5HallsFromSiteTag(siteTag)){
             String gw = "gw1";
             block = block.toLowerCase();
             String site = siteTag.split("_")[1];
@@ -134,13 +136,14 @@ public class AcControllerResolver {
         return Map.of("topic_pub", topicPub, "topic_sub", topicSub, "pma_path", pmaPath);
     }
 
-    Boolean isFiveHalls(String siteTag){
+    Boolean isNus5HallsFromSiteTag(String siteTag){
         if(siteTag == null || siteTag.isEmpty()){
             return false;
         }
 
         siteTag = siteTag.toLowerCase();
-        return "nus_eh".equals(siteTag) || "nus_ke7h".equals(siteTag) || "nus_krh".equals(siteTag)
-                || "nus_sh".equals(siteTag) || "nus_th".equals(siteTag);
+//        return "nus_eh".equals(siteTag) || "nus_ke7h".equals(siteTag) || "nus_krh".equals(siteTag)
+//                || "nus_sh".equals(siteTag) || "nus_th".equals(siteTag);
+        return siteTagNus5HallsList.contains(siteTag);
     }
 }


### PR DESCRIPTION
This pull request updates the EVS2 Helper module version and refactors how "NUS 5 Halls" site tags are handled in the `AcControllerResolver` class. The main focus is on improving maintainability by centralizing the list of relevant site tags and renaming methods for clarity.

**Version update:**

* Updated the project version in `pom.xml` from `3.58.13` to `3.58.14`.

**Refactoring and maintainability improvements:**

* Introduced a new constant `siteTagNus5HallsList` to hold the list of "NUS 5 Halls" site tags, centralizing the definition for easier maintenance.
* Renamed the method `isFiveHalls` to `isNus5HallsFromSiteTag` for better clarity, and updated all usages accordingly. [[1]](diffhunk://#diff-36f631e00210a20ca635fa07ec643eb31f67475b578575c5cd13bdd3ea472ce9L121-R123) [[2]](diffhunk://#diff-36f631e00210a20ca635fa07ec643eb31f67475b578575c5cd13bdd3ea472ce9L137-R147)
* Refactored the logic in `isNus5HallsFromSiteTag` to use the new `siteTagNus5HallsList` instead of hardcoding the site tag checks, making it easier to update the list in the future.

No business logic has changed—these are internal improvements for code clarity and maintainability.