### PR TITLE
pgpr6 meters adhoc update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.59.0</version>
+	<version>3.59.1</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/cpc/AcControllerGatewayResolver.java
+++ b/src/main/java/org/pabuff/evs2helper/cpc/AcControllerGatewayResolver.java
@@ -16,6 +16,58 @@ public class AcControllerGatewayResolver {
     private String acControllerGatewayTag;
     private static final List<String> siteTagNus5HallsList = List.of("nus_eh", "nus_ke7h", "nus_krh", "nus_sh", "nus_th");
 
+    // 48 meters at PGPR 6 are controlled by the ac controller at pgpr 5
+    static private final List<String> pgpr6AdhocMeter = List.of(
+            "201808000338",
+            "201808000340",
+            "201808000268",
+            "201808000271",
+            "201808000270",
+            "201808000247",
+            "201808000336",
+            "201808000253",
+            "201808000255",
+            "201906000050",
+            "201906000139",
+            "201906000044",
+            "201906000370",
+            "201906000382",
+            "201906000138",
+            "201906000134",
+            "201906000381",
+            "201906000385",
+            "201906000029",
+            "201906000017",
+            "201906000028",
+            "201906000019",
+            "201906000025",
+            "201906000201",
+            "201906000380",
+            "201906000132",
+            "201906000042",
+            "201906000265",
+            "201906000267",
+            "201906000205",
+            "201906000207",
+            "201906000383",
+            "201906000337",
+            "201906000336",
+            "201906000319",
+            "201906000317",
+            "201906000188",
+            "201906000186",
+            "201906000192",
+            "201906000193",
+            "201906000327",
+            "201906000325",
+            "201906000181",
+            "201906000187",
+            "201906000144",
+            "201906000146",
+            "201906000081",
+            "201906000077");
+
+
     public Map<String, Object> resolveGateway(Map<String, Object> scope) {
         logger.info("resolveGateway()");
 
@@ -77,6 +129,12 @@ public class AcControllerGatewayResolver {
                 topicSubscribe = "evs2/nus/vh/" + gw + "/" + meterSn;
                 break;
             case "nus_pgpr":
+                if("6".equals(block)){
+                    if(pgpr6AdhocMeter.contains(meterSn)){
+                        block = "5";
+                    }
+                }
+
                 topicPublish = "evs2/nus/pgpr" + block + "/" + gw;
                 topicSubscribe = "evs2/nus/pgpr" + block + "/" + gw + "/" + meterSn;
                 break;


### PR DESCRIPTION
This pull request updates the EVS2 Helper module to support special handling for certain meters at PGPR 6. The main change is to ensure that 48 specific meters at PGPR 6 are associated with the AC controller at PGPR 5, which affects how gateway topics are resolved. The version number is also incremented.

**PGPR 6 Adhoc Meter Handling:**

* Added a static list `pgpr6AdhocMeter` to `AcControllerGatewayResolver` containing the serial numbers of 48 meters at PGPR 6 that should be controlled by the AC controller at PGPR 5.
* Updated the logic in `resolveGatewayTopic` to check if the meter is in `pgpr6AdhocMeter` when the block is "6", and if so, reassign the block to "5" for topic resolution.

**Version Update:**

* Bumped the module version from `3.59.0` to `3.59.1` in `pom.xml`.