### PR TITLE
getTcmPath update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.pabuff</groupId>
 	<artifactId>evs2helper</artifactId>
-	<version>3.59.3</version>
+	<version>3.59.4</version>
 	<name>evs2helper</name>
 	<description>EVS2 Helper Module</description>
 

--- a/src/main/java/org/pabuff/evs2helper/TcmHelper2.java
+++ b/src/main/java/org/pabuff/evs2helper/TcmHelper2.java
@@ -32,6 +32,8 @@ public class TcmHelper2 {
     private String tcmPathSutdCampus;
     @Value("${tcm.path.nus_five_halls}")
     private String tcmPathNusFiveHalls;
+    @Value("${tcm.path.pa_atp}")
+    private String tcmPathPaAtp;
 
     @Value("${tcm.ept.do_one_topup}")
     private String tcmEptDoOneTopup;
@@ -136,6 +138,8 @@ public class TcmHelper2 {
                 return tcmPathSutdCampus;
             } else if (nusHallsSiteTagList.contains(siteTag)) {
                 return tcmPathNusFiveHalls;
+            } else if ("pa_atp".equals(siteTag)) {
+                return tcmPathPaAtp;
             }
         }
         return tcmPath;


### PR DESCRIPTION
This pull request introduces support for a new site tag, `pa_atp`, in the `TcmHelper2` class and updates the project version. The main changes are grouped into versioning and feature enhancements.

**Versioning:**
* Updated the project version in `pom.xml` from `3.59.3` to `3.59.4`, indicating a new release with added functionality.

**Feature enhancements:**
* Added a new configuration property `tcm.path.pa_atp` and the corresponding field `tcmPathPaAtp` to `TcmHelper2`, allowing the application to retrieve the TCM path for the `pa_atp` site tag.
* Updated the `getTcmPath` method in `TcmHelper2` to handle the `pa_atp` site tag and return the correct path when this tag is encountered.